### PR TITLE
Align theme card thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Add edit option on admin area page displaying list of items comtained by a conte
 
 Users will be prompted when leaving a page that has unsaved changes unless the form is being submitted.
 
+### Theme card thumbnail alignment
+
+Minor tweak to align thumbnails on theme cards when selecting a theme - particularly noticeable on larger screens.
+
 ## Development
 
 ### Prerequisities

--- a/wwwroot/Styles/admin-theme-overrides.css
+++ b/wwwroot/Styles/admin-theme-overrides.css
@@ -249,3 +249,7 @@ body:not(.left-sidebar-compact)
 [dir] .form-control:focus {
   background: #f9f9fb;
 }
+
+.theme-card .card-theme-thumbnail {
+  background-position: center center;
+}


### PR DESCRIPTION
This has always annoyed me - on larger screens, these scale up to fill the width (by aspect ratio) and get chopped off. The least we can do is center them so that when it's a logo, it's less likely to end up getting chopped :)

Before: 
![image](https://user-images.githubusercontent.com/2920312/119843297-5233da80-beff-11eb-8727-0b52865452ea.png)

After: 
![image](https://user-images.githubusercontent.com/2920312/119843341-5fe96000-beff-11eb-9964-1c843cfca819.png)
