### PR TITLE
Fix incorrect target on bag/flow parts

### DIFF
--- a/Etch.OrchardCore.AdminTheme.csproj
+++ b/Etch.OrchardCore.AdminTheme.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <PackageId>Etch.OrchardCore.AdminTheme</PackageId>
     <Title>Admin Theme</Title>
     <Authors>Etch UK</Authors>

--- a/Manifest.cs
+++ b/Manifest.cs
@@ -4,7 +4,7 @@ using OrchardCore.DisplayManagement.Manifest;
     Name = "Admin Theme",
     Author = "EtchUK Ltd.",
     Website = "https://etchuk.com/",
-    Version = "1.2.0",
+    Version = "1.2.1",
     Description = "Extension of TheAdmin theme.",
     Tags = new[] { "admin" },
     BaseTheme = "TheAdmin"

--- a/Views/BagPart.Edit.cshtml
+++ b/Views/BagPart.Edit.cshtml
@@ -40,7 +40,11 @@
 
 <div class="form-group">
     <div id="@widgetTemplatePlaceholderId" class="widget-template-placeholder widget-template-placeholder-bagpart bagpart-@partName.HtmlClassify() row mx-0" data-buildeditorurl="@Url.Action("BuildEditor", "Admin", new { area = "OrchardCore.Flows" })">
-        @{ var htmlFieldPrefix = this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix; }
+        @{ 
+            var htmlFieldPrefix = this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
+            var index = 0;
+        }
+
         @foreach (var widget in Model.BagPart.ContentItems)
         {
             //Create a Card Shape
@@ -60,8 +64,8 @@
                 CanDelete: true,
                 //Input hidden
                 //Prefixes
-                PrefixValue: widget.ContentItemId,
                 HtmlFieldPrefix: htmlFieldPrefix,
+                PrefixValue: htmlFieldPrefix + '-' + (index++).ToString(),
                 PrefixesId: Html.IdFor(x => x.Prefixes),
                 PrefixesName: Html.NameFor(x => x.Prefixes),
                 //Content Types
@@ -79,6 +83,7 @@
                 {
                     <a class="btn btn-primary btn-sm add-widget"
                        data-target-id="@widgetTemplatePlaceholderId"
+                       data-html-field-prefix="@htmlFieldPrefix"
                        data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
                        data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
                        data-widget-type="@Model.ContainedContentTypeDefinitions.FirstOrDefault().Name"
@@ -151,6 +156,7 @@
                                         <div class="card-footer text-muted text-xs-right">
                                             <a class="btn btn-primary btn-sm add-widget"
                                                data-target-id="@widgetTemplatePlaceholderId"
+                                               data-html-field-prefix="@htmlFieldPrefix"
                                                data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
                                                data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
                                                data-widget-type="@type.Name"

--- a/Views/FlowPart.Edit.cshtml
+++ b/Views/FlowPart.Edit.cshtml
@@ -41,7 +41,11 @@
 
 <div class="form-group">
     <div id="@widgetTemplatePlaceholderId" class="widget-template-placeholder widget-template-placeholder-flowpart flowpart-@partName.HtmlClassify() row mx-0" data-buildeditorurl="@Url.Action("BuildEditor", "Admin", new { area = "OrchardCore.Flows" })">
-        @{ var htmlFieldPrefix = this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix; }
+        @{ 
+            var htmlFieldPrefix = this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
+            var index = 0;
+        }
+
         @foreach (var widget in Model.FlowPart.Widgets)
         {
             var metadata = ((ContentItem)widget).As<OrchardCore.Flows.Models.FlowMetadata>();
@@ -67,8 +71,8 @@
                 CanDelete: true,
                 //Input hidden
                 //Prefixes
-                PrefixValue: widget.ContentItemId,
                 HtmlFieldPrefix: htmlFieldPrefix,
+                PrefixValue: htmlFieldPrefix + '-' + (index++).ToString(),
                 PrefixesId: widget.ContentItemId + "_" + Html.IdFor(x => x.Prefixes),
                 PrefixesName: Html.NameFor(x => x.Prefixes),
                 //Content Types
@@ -143,6 +147,7 @@
                                     <div class="card-footer text-muted text-xs-right">
                                         <a class="btn btn-primary btn-sm add-widget"
                                            data-target-id="@widgetTemplatePlaceholderId"
+                                           data-html-field-prefix="@htmlFieldPrefix"
                                            data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
                                            data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
                                            data-widget-type="@type.Name"


### PR DESCRIPTION
Issue was with the lack of a html-field-prefix data attribute on the add buttons which meant it was possible for the target to be a different bag or flow.